### PR TITLE
大佬，发现您的项目引入了org.springframework:spring-core@5.0.12.RELEASE组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>me.dslztx</groupId>
@@ -38,7 +37,7 @@
         <me.dslztx.mockito.version>2.20.0</me.dslztx.mockito.version>
         <me.dslztx.alibaba.fastjson.version>1.2.56</me.dslztx.alibaba.fastjson.version>
         <me.dslztx.mybatis.version>3.3.0</me.dslztx.mybatis.version>
-        <me.dslztx.spring.version>5.0.12.RELEASE</me.dslztx.spring.version>
+        <me.dslztx.spring.version>5.2.19.RELEASE</me.dslztx.spring.version>
 
         <plugin-compiler.version>3.0</plugin-compiler.version>
         <plugin-compiler.compile.encoding>UTF-8</plugin-compiler.compile.encoding>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Vmware Spring Framework 注入漏洞
缺陷组件：org.springframework:spring-core@5.0.12.RELEASE
漏洞编号：CVE-2021-22096
漏洞描述：Vmware Spring Framework是美国威睿（Vmware）公司的一套开源的Java、JavaEE应用程序框架。该框架可帮助开发人员构建高质量的应用。
Spring Framework 存在注入漏洞，该漏洞源于通过日志注入绕过 Spring Framework 的访问限制，以更改数据。
影响范围：(∞, 5.2.18)
最小修复版本：5.2.19.RELEASE
缺陷组件引入路径：me.dslztx:assist-spring-web@1.0.0->org.springframework:spring-aop@5.0.12.RELEASE->org.springframework:spring-core@5.0.12.RELEASE
me.dslztx:assist-spring-web@1.0.0->org.springframework:spring-core@5.0.12.RELEASE
me.dslztx:assist-spring-web@1.0.0->org.springframework:spring-context@5.0.12.RELEASE->org.springframework:spring-aop@5.0.12.RELEASE->org.springframework:spring-core@5.0.12.RELEASE
me.dslztx:assist-spring-web@1.0.0->org.springframework:spring-context@5.0.12.RELEASE->org.springframework:spring-beans@5.0.12.RELEASE->org.springframework:spring-core@5.0.12.RELEASE
me.dslztx:assist-spring-web@1.0.0->org.springframework:spring-context@5.0.12.RELEASE->org.springframework:spring-core@5.0.12.RELEASE
me.dslztx:assist-spring-web@1.0.0->org.springframework:spring-context@5.0.12.RELEASE->org.springframework:spring-expression@5.0.12.RELEASE->org.springframework:spring-core@5.0.12.RELEASE
me.dslztx:assist-spring-web@1.0.0->org.springframework:spring-beans@5.0.12.RELEASE->org.springframework:spring-core@5.0.12.RELEASE
me.dslztx:assist-spring-web@1.0.0->org.springframework:spring-context@5.0.12.RELEASE->org.springframework:spring-aop@5.0.12.RELEASE->org.springframework:spring-beans@5.0.12.RELEASE->org.springframework:spring-core@5.0.12.RELEASE
me.dslztx:assist-spring-web@1.0.0->org.springframework:spring-aop@5.0.12.RELEASE->org.springframework:spring-beans@5.0.12.RELEASE->org.springframework:spring-core@5.0.12.RELEASE
```
另外我运行这个项目时，IDE的安全插件提示还有3个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p96558